### PR TITLE
Wechsel zwischen den Screens auf dem Eltern-Dashboard

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -47,3 +47,4 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 - `npm i --save-dev @types/react-router-dom`
 - `npm install @microsoft/signalr`
 - `npm install recoil`
+- `npm install @material-ui/icons`

--- a/client/README.md
+++ b/client/README.md
@@ -46,3 +46,4 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 - `npm install react-router-dom`
 - `npm i --save-dev @types/react-router-dom`
 - `npm install @microsoft/signalr`
+- `npm install recoil`

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1753,6 +1753,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12876,6 +12876,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recoil": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.1.2.tgz",
+      "integrity": "sha512-hIRrHlkmW4yITlBFprVYjVPhzPKYrJKoaDrrJtAtbkMeXfXaa/XE5OlyR10n+rNfnKWNToCKb3Z4fo86IGjkzg=="
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.3",
+    "@material-ui/icons": "^4.11.2",
     "@microsoft/signalr": "^5.0.3",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",

--- a/client/package.json
+++ b/client/package.json
@@ -17,8 +17,12 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "recoil": "^0.1.2",
     "typescript": "^4.1.5",
     "web-vitals": "^1.1.0"
+  },
+  "devDependencies": {
+    "@types/react-router-dom": "^5.1.7"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -43,8 +47,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "@types/react-router-dom": "^5.1.7"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,25 +6,48 @@ import { ChildScreen } from "./child/ChildScreen";
 import { ParentScreen } from "./parent/ParentScreen";
 import { HomeScreen } from "./home/HomeScreen";
 import { RecoilRoot } from "recoil";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles({
+  linkList: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    overflow: "hidden",
+    backgroundColor: "#333333",
+  },
+  linkListItem: {
+    float: "left",
+  },
+  link: {
+    display: "block",
+    color: "#fff",
+    textAlign: "center",
+    padding: "0px 16px 0px 16px",
+    textDecoration: "none",
+  }
+});
 
 function App() {
+  const classes = useStyles();
+
   return (
     <RecoilRoot>
       <Router>
         <div className="App">
           <nav>
-            <ul>
-              <li>
-                <Link to="/">Home</Link>
+            <ul className={classes.linkList}>
+              <li className={classes.linkListItem}>
+                <Link className={classes.link} to="/">Home</Link>
               </li>
-              <li>
-                <Link to="/login">Login</Link>
+              <li className={classes.linkListItem}>
+                <Link className={classes.link} to="/login">Login</Link>
               </li>
-              <li>
-                <Link to="/child">Child</Link>
+              <li className={classes.linkListItem}>
+                <Link className={classes.link} to="/child">Child</Link>
               </li>
-              <li>
-                <Link to="/parent">Parent</Link>
+              <li className={classes.linkListItem}>
+                <Link className={classes.link} to="/parent">Parent</Link>
               </li>
             </ul>
           </nav>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,17 +9,17 @@ import { RecoilRoot } from "recoil";
 import { makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles({
-  linkList: {
+  linkList: { // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
     listStyle: "none",
     margin: 0,
     padding: 0,
     overflow: "hidden",
     backgroundColor: "#333333",
   },
-  linkListItem: {
+  linkListItem: { // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
     float: "left",
   },
-  link: {
+  link: { // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
     display: "block",
     color: "#fff",
     textAlign: "center",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,17 +15,17 @@ const useStyles = makeStyles({
     padding: 0,
     overflow: "hidden",
     backgroundColor: "#333333",
+    "& > *": { // list items
+      float: "left",
+      "& > *": { // link
+        display: "block",
+        color: "#fff",
+        textAlign: "center",
+        padding: "0px 16px 0px 16px",
+        textDecoration: "none",
+      }
+    }
   },
-  linkListItem: { // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
-    float: "left",
-  },
-  link: { // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
-    display: "block",
-    color: "#fff",
-    textAlign: "center",
-    padding: "0px 16px 0px 16px",
-    textDecoration: "none",
-  }
 });
 
 // TODO js (25.02.2021): Nav element is only temporary remove it when ready.
@@ -38,17 +38,17 @@ function App() {
         <div className="App">
           <nav>
             <ul className={classes.linkList}>
-              <li className={classes.linkListItem}>
-                <Link className={classes.link} to="/">Home</Link>
+              <li>
+                <Link to="/">Home</Link>
               </li>
-              <li className={classes.linkListItem}>
-                <Link className={classes.link} to="/login">Login</Link>
+              <li>
+                <Link to="/login">Login</Link>
               </li>
-              <li className={classes.linkListItem}>
-                <Link className={classes.link} to="/child">Child</Link>
+              <li>
+                <Link to="/child">Child</Link>
               </li>
-              <li className={classes.linkListItem}>
-                <Link className={classes.link} to="/parent">Parent</Link>
+              <li>
+                <Link to="/parent">Parent</Link>
               </li>
             </ul>
           </nav>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles({
   }
 });
 
+// TODO js (25.02.2021): Nav element is only temporary remove it when ready.
 function App() {
   const classes = useStyles();
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,44 +5,47 @@ import { LoginScreen } from "./login/LoginScreen";
 import { ChildScreen } from "./child/ChildScreen";
 import { ParentScreen } from "./parent/ParentScreen";
 import { HomeScreen } from "./home/HomeScreen";
+import { RecoilRoot } from "recoil";
 
 function App() {
   return (
-    <Router>
-      <div className="App">
-        <nav>
-          <ul>
-            <li>
-              <Link to="/">Home</Link>
-            </li>
-            <li>
-              <Link to="/login">Login</Link>
-            </li>
-            <li>
-              <Link to="/child">Child</Link>
-            </li>
-            <li>
-              <Link to="/parent">Parent</Link>
-            </li>
-          </ul>
-        </nav>
+    <RecoilRoot>
+      <Router>
+        <div className="App">
+          <nav>
+            <ul>
+              <li>
+                <Link to="/">Home</Link>
+              </li>
+              <li>
+                <Link to="/login">Login</Link>
+              </li>
+              <li>
+                <Link to="/child">Child</Link>
+              </li>
+              <li>
+                <Link to="/parent">Parent</Link>
+              </li>
+            </ul>
+          </nav>
 
-        <Switch>
-          <Route path="/login">
-            <LoginScreen />
-          </Route>
-          <Route path="/child">
-            <ChildScreen />
-          </Route>
-          <Route path="/parent">
-            <ParentScreen />
-          </Route>
-          <Route path="/">
-            <HomeScreen />
-          </Route>
-        </Switch>
-      </div>
-    </Router>
+          <Switch>
+            <Route path="/login">
+              <LoginScreen />
+            </Route>
+            <Route path="/child">
+              <ChildScreen />
+            </Route>
+            <Route path="/parent">
+              <ParentScreen />
+            </Route>
+            <Route path="/">
+              <HomeScreen />
+            </Route>
+          </Switch>
+        </div>
+      </Router>
+    </RecoilRoot>
   );
 }
 

--- a/client/src/AppState.tsx
+++ b/client/src/AppState.tsx
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const currentScreen = atom({
+  key: "currentScreen",
+  default: "",
+});

--- a/client/src/child/ChildScreen.tsx
+++ b/client/src/child/ChildScreen.tsx
@@ -1,3 +1,9 @@
+import { DashboardLayout } from "../shell/DashboardLayout";
+
 export function ChildScreen() {
-  return <p>ChildScreen</p>;
+  return (
+    <DashboardLayout>
+      <p>Child Screen</p>
+    </DashboardLayout>
+  );
 }

--- a/client/src/child/ChildScreen.tsx
+++ b/client/src/child/ChildScreen.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { DashboardLayout } from "../shell/DashboardLayout";
 
 export function ChildScreen() {
-  const [title, ] = useState("Ämtli Pinwand");
+  const [title, ] = useState("Ämtli Pinwand"); // TODO js (25.02.2021): Set title depending on state of the app.
+  const [avatarAlt, ] = useState("Lio"); // TODO js (25.02.2021): Set the avatar alt value depending on logged in user.
+  const [avatarSrc, ] = useState(""); // TODO js (25.02.2021): Set the avatar src depending on logged in user.
 
   return (
-    <DashboardLayout avatarAlt="Lio" avatarSrc="" title={title}>
+    <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title={title}>
       <p>Child Screen</p>
     </DashboardLayout>
   );

--- a/client/src/child/ChildScreen.tsx
+++ b/client/src/child/ChildScreen.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { DashboardLayout } from "../shell/DashboardLayout";
 
 export function ChildScreen() {
+  const [title, ] = useState("Ämtli Pinwand");
+
   return (
-    <DashboardLayout>
+    <DashboardLayout avatarAlt="Lio" avatarSrc="" title={title}>
       <p>Child Screen</p>
     </DashboardLayout>
   );

--- a/client/src/home/HomeScreen.tsx
+++ b/client/src/home/HomeScreen.tsx
@@ -1,6 +1,8 @@
 import { HubConnection, HubConnectionBuilder } from "@microsoft/signalr";
 import axios from "axios";
 import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import { currentScreen } from "../AppState";
 
 const apiBaseUrl = process.env.REACT_APP_APIBASEURL as string;
 const apiRestTestUrl = `${apiBaseUrl}/api/weatherforecast`;
@@ -18,11 +20,13 @@ interface Message {
 }
 
 export function HomeScreen() {
+  const [screen, setScreen] = useRecoilState(currentScreen);
   const [apiData, setApiData] = useState<WeatherForecast[]>([]);
   const [hubConnection, setHubConnection] = useState<HubConnection>();
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
+    setScreen(val => 'Home');
     console.log("HomeScreen - Mounting component...");
     const getDataFromRestApi = async () => {
       console.log("REST API >>> Connecting", apiRestTestUrl);
@@ -30,7 +34,6 @@ export function HomeScreen() {
       console.log("REST API >>> Result", apiRestTestUrl);
       setApiData(result.data);
     };
-
     const createHubConnection = async () => {
       if (hubConnection == null) {
         console.log("SignalR >>> Connecting", hubTestUrl);

--- a/client/src/model/Child.ts
+++ b/client/src/model/Child.ts
@@ -1,0 +1,4 @@
+export type Child = {
+    id: number;
+    name: string;
+}

--- a/client/src/model/Chore.ts
+++ b/client/src/model/Chore.ts
@@ -1,0 +1,10 @@
+import { ChoreAssignement } from "./ChoreAssignment";
+
+export type Chore = {
+    id: number;
+    name: string;
+    description: string;
+    dueDate: number;
+    value: number;
+    assignments: ChoreAssignement[];
+}

--- a/client/src/model/ChoreAssignment.ts
+++ b/client/src/model/ChoreAssignment.ts
@@ -1,0 +1,7 @@
+import { Child } from "./Child";
+
+export type ChoreAssignement = {
+    isDone: boolean;
+    isConfirmed: boolean;
+    assignee: Child;
+}

--- a/client/src/parent/ChoreTable.tsx
+++ b/client/src/parent/ChoreTable.tsx
@@ -1,0 +1,157 @@
+import { Paper, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, makeStyles } from "@material-ui/core";
+import { useEffect, useState } from "react";
+import { Chore } from "../model/Chore";
+import { ChoreTableRow } from "./ChoreTableRow";
+
+// TODO js (25.02.2021): Remove dummy data as soon as data is consumed from backend.
+const lars = {
+    id: 1,
+    name: "Lars",
+    avatarSrc: ""
+ };
+ const lara = {
+    id: 2,
+    name: "Lara",
+    avatarSrc: ""
+ };
+ const lena = {
+    id: 3,
+    name: "Lena",
+    avatarSrc: ""
+ };
+
+ const useStyles = makeStyles({
+     container: {
+         flex: "1 1 auto",
+     }
+ });
+
+export function ChoreTable() {
+    const [chores, setChores] = useState<Chore[]>([]);
+    const classes = useStyles();
+
+    useEffect(() => {
+        setChores([ // TODO js (25.02.2021): Remove dummy data as soon as data is consumed from backend.
+            {
+                id: 42, 
+                name: "Rasen mähen",
+                description: "", 
+                dueDate: Date.now(),
+                value: 20,
+                assignments: [
+                    {
+                        isDone: true,
+                        isConfirmed: false,
+                        assignee: lara
+                    }
+                ],
+            },
+            {
+                id: 1, 
+                name: "Zimmer staubsaugen",
+                description: "", 
+                dueDate: Date.now(),
+                value: 10, 
+                assignments: [
+                    {
+                        isDone: false,
+                        isConfirmed: false,
+                        assignee: lars
+                    },
+                    {
+                        isDone: true,
+                        isConfirmed: false,
+                        assignee: lara
+                    },
+                    {
+                        isDone: true,
+                        isConfirmed: true,
+                        assignee: lena
+                    }
+                ]
+            },
+            {
+                id: 2, 
+                name: "Abfall rausbringen",
+                description: "", 
+                dueDate: Date.now(),
+                value: 5,
+                assignments: [
+                    {
+                        isDone: true,
+                        isConfirmed: false,
+                        assignee: lara
+                    },
+                    {
+                        isDone: false,
+                        isConfirmed: false,
+                        assignee: lena
+                    }
+                ],
+            },
+            {
+                id: 3, 
+                name: "Abwaschen",
+                description: "", 
+                dueDate: Date.now(),
+                value: 5,
+                assignments: [
+                    {
+                        isDone: true,
+                        isConfirmed: false,
+                        assignee: lara
+                    },
+                    {
+                        isDone: false,
+                        isConfirmed: false,
+                        assignee: lena
+                    }
+                ],
+            },
+            {
+                id: 4, 
+                name: "Zimmer aufräumen",
+                description: "", 
+                dueDate: Date.now(),
+                value: 10, 
+                assignments: [
+                    {
+                        isDone: false,
+                        isConfirmed: false,
+                        assignee: lars
+                    },
+                    {
+                        isDone: true,
+                        isConfirmed: false,
+                        assignee: lara
+                    },
+                    {
+                        isDone: true,
+                        isConfirmed: true,
+                        assignee: lena
+                    }
+                ]
+            },
+        ]);   
+    }, []);
+
+    return (
+        <TableContainer className={classes.container} component={Paper}>
+            <Table stickyHeader aria-label="sticky table" size="small">
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Ämtli</TableCell>
+                        <TableCell></TableCell>
+                        <TableCell align="center">Done</TableCell>
+                        <TableCell></TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {chores.map((chore) => (
+                        <ChoreTableRow key={chore.id} chore={chore} />
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+}

--- a/client/src/parent/ChoreTable.tsx
+++ b/client/src/parent/ChoreTable.tsx
@@ -1,7 +1,9 @@
-import { Paper, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, makeStyles } from "@material-ui/core";
+import { Paper, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, makeStyles, createStyles, Theme } from "@material-ui/core";
 import { useEffect, useState } from "react";
 import { Chore } from "../model/Chore";
 import { ChoreTableRow } from "./ChoreTableRow";
+import { Fab } from "@material-ui/core";
+import AddIcon from '@material-ui/icons/Add';
 
 // TODO js (25.02.2021): Remove dummy data as soon as data is consumed from backend.
 const lars = {
@@ -20,11 +22,18 @@ const lars = {
     avatarSrc: ""
  };
 
- const useStyles = makeStyles({
+ const useStyles = makeStyles((theme: Theme) => 
+    createStyles({
      container: {
          flex: "1 1 auto",
-     }
- });
+     },
+     fab: {
+        position: 'absolute',
+        bottom: theme.spacing(6),
+        right: theme.spacing(2),
+      },
+    }),
+ );
 
 export function ChoreTable() {
     const [chores, setChores] = useState<Chore[]>([]);
@@ -143,7 +152,7 @@ export function ChoreTable() {
                         <TableCell>Ämtli</TableCell>
                         <TableCell></TableCell>
                         <TableCell align="center">Done</TableCell>
-                        <TableCell></TableCell>
+                        <TableCell align="center">Bestätigen</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -152,6 +161,9 @@ export function ChoreTable() {
                     ))}
                 </TableBody>
             </Table>
+            <Fab className={classes.fab} size="small" color="primary" aria-label="add">
+                <AddIcon />
+            </Fab>
         </TableContainer>
     );
 }

--- a/client/src/parent/ChoreTableRow.tsx
+++ b/client/src/parent/ChoreTableRow.tsx
@@ -1,0 +1,43 @@
+import { TableRow, TableCell, Checkbox, Button, makeStyles } from "@material-ui/core";
+import { Chore } from "../model/Chore";
+
+const useStyles = makeStyles({
+    row: {
+        "& > *": {
+            borderBottom: "unset",
+        },
+    },
+    assignmentRow: {
+        "& > *": {
+            borderBottom: "unset",
+        },
+    },
+});
+
+type Prop = {
+    chore: Chore
+}
+
+export function ChoreTableRow(props: Prop) {
+    const classes = useStyles();
+
+    return (
+        <>
+            <TableRow className={classes.row} key={props.chore.id}>
+                <TableCell component="th" scope="row" colSpan={4}>
+                    {props.chore.name}
+                </TableCell>
+            </TableRow>
+            {props.chore.assignments.map((assignment, index) => {
+                return (
+                    <TableRow className={index !== props.chore.assignments.length - 1 ? classes.assignmentRow : ""} key={`${props.chore.id}${assignment.assignee.id}`} >
+                        <TableCell component="th" scope="row"></TableCell>
+                        <TableCell align="left">{assignment.assignee.name}</TableCell>
+                        <TableCell align="center"><Checkbox checked={assignment.isDone} disabled size="small"/></TableCell>
+                        <TableCell align="center">{assignment.isDone && !assignment.isConfirmed ? <Button variant="contained" color="primary" size="small">Ok</Button> : ""}</TableCell>
+                    </TableRow>
+                );
+            })}
+        </>
+    );
+}

--- a/client/src/parent/ParentScreen.tsx
+++ b/client/src/parent/ParentScreen.tsx
@@ -20,7 +20,7 @@ export function ParentScreen() {
           <p>Profil...</p>
         </DashboardLayout>
       </Route>
-      <Route path={path}>
+      <Route path={[`${path}/chores`, path]} exact>
         <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title="Ämtli Pinwand">
           <ChoreTable/>
         </DashboardLayout>

--- a/client/src/parent/ParentScreen.tsx
+++ b/client/src/parent/ParentScreen.tsx
@@ -1,15 +1,30 @@
 import { useState } from "react";
 import { DashboardLayout } from "../shell/DashboardLayout";
 import { ChoreTable } from "./ChoreTable";
+import { BrowserRouter as  Switch, Route, useRouteMatch } from "react-router-dom";
 
 export function ParentScreen() {
-  const [title, ] = useState("Ämtli Pinwand"); // TODO js (25.02.2021): Set title depending on state of the app.
+  const {path, } = useRouteMatch();
   const [avatarAlt, ] = useState("Mami"); // TODO js (25.02.2021): Set the avatar alt value depending on logged in user.
   const [avatarSrc, ] = useState(""); // TODO js (25.02.2021): Set the avatar src depending on logged in user.
 
   return (
-    <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title={title}>
-      <ChoreTable/>
-    </DashboardLayout>
+    <Switch>
+      <Route path={`${path}/rewards`}>
+        <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title="Belohungs-Pinwand">
+          <p>Belohnungen...</p>
+        </DashboardLayout>
+      </Route>
+      <Route path={`${path}/profile`}>
+        <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title="Profil">
+          <p>Profil...</p>
+        </DashboardLayout>
+      </Route>
+      <Route path={path}>
+        <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title="Ämtli Pinwand">
+          <ChoreTable/>
+        </DashboardLayout>
+      </Route>
+    </Switch>
   );
 }

--- a/client/src/parent/ParentScreen.tsx
+++ b/client/src/parent/ParentScreen.tsx
@@ -1,3 +1,10 @@
+import { DashboardLayout } from "../shell/DashboardLayout";
+
 export function ParentScreen() {
-  return <p>ParentScreen</p>;
+
+  return (
+    <DashboardLayout>
+      <p>Parent Screen</p>
+    </DashboardLayout>
+  );
 }

--- a/client/src/parent/ParentScreen.tsx
+++ b/client/src/parent/ParentScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { DashboardLayout } from "../shell/DashboardLayout";
+import { ChoreTable } from "./ChoreTable";
 
 export function ParentScreen() {
   const [title, ] = useState("Ämtli Pinwand"); // TODO js (25.02.2021): Set title depending on state of the app.
@@ -8,7 +9,7 @@ export function ParentScreen() {
 
   return (
     <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title={title}>
-      <p>Parent Screen</p>
+      <ChoreTable/>
     </DashboardLayout>
   );
 }

--- a/client/src/parent/ParentScreen.tsx
+++ b/client/src/parent/ParentScreen.tsx
@@ -1,9 +1,13 @@
+import { useState } from "react";
 import { DashboardLayout } from "../shell/DashboardLayout";
 
 export function ParentScreen() {
+  const [title, ] = useState("Ämtli Pinwand"); // TODO js (25.02.2021): Set title depending on state of the app.
+  const [avatarAlt, ] = useState("Mami"); // TODO js (25.02.2021): Set the avatar alt value depending on logged in user.
+  const [avatarSrc, ] = useState(""); // TODO js (25.02.2021): Set the avatar src depending on logged in user.
 
   return (
-    <DashboardLayout>
+    <DashboardLayout avatarAlt={avatarAlt} avatarSrc={avatarSrc} title={title}>
       <p>Parent Screen</p>
     </DashboardLayout>
   );

--- a/client/src/shell/DashboardLayout.tsx
+++ b/client/src/shell/DashboardLayout.tsx
@@ -1,0 +1,18 @@
+import { Box } from "@material-ui/core";
+import { ReactNode } from "react";
+import { NavigationBar } from "./NavigationBar";
+import { TitleBar } from "./TitleBar";
+
+type Props = {
+    children: ReactNode
+}
+
+export function DashboardLayout(props: Props) {
+    return (
+        <Box display="flex" flexDirection="column" justifyContent="space-between">
+            <TitleBar />
+                {props.children}
+            <NavigationBar />
+        </Box>
+    );
+}

--- a/client/src/shell/DashboardLayout.tsx
+++ b/client/src/shell/DashboardLayout.tsx
@@ -6,7 +6,7 @@ import { TitleBar } from "./TitleBar";
 const useStyles = makeStyles({
     boxRoot: {
         height: "100vh",
-    }
+    },
 });
 
 type Props = {

--- a/client/src/shell/DashboardLayout.tsx
+++ b/client/src/shell/DashboardLayout.tsx
@@ -1,17 +1,25 @@
-import { Box } from "@material-ui/core";
+import { Box, makeStyles } from "@material-ui/core";
 import { ReactNode } from "react";
 import { NavigationBar } from "./NavigationBar";
 import { TitleBar } from "./TitleBar";
+
+const useStyles = makeStyles({
+    boxRoot: {
+        height: "100vh",
+    }
+});
 
 type Props = {
     children: ReactNode
 }
 
 export function DashboardLayout(props: Props) {
+    const classes = useStyles();
+
     return (
-        <Box display="flex" flexDirection="column" justifyContent="space-between">
+        <Box className={classes.boxRoot} display="flex" flexDirection="column" justifyContent="space-between">
             <TitleBar />
-                {props.children}
+            {props.children}
             <NavigationBar />
         </Box>
     );

--- a/client/src/shell/DashboardLayout.tsx
+++ b/client/src/shell/DashboardLayout.tsx
@@ -10,7 +10,10 @@ const useStyles = makeStyles({
 });
 
 type Props = {
-    children: ReactNode
+    children: ReactNode;
+    title: string;
+    avatarAlt: string;
+    avatarSrc: string;
 }
 
 export function DashboardLayout(props: Props) {
@@ -18,7 +21,7 @@ export function DashboardLayout(props: Props) {
 
     return (
         <Box className={classes.boxRoot} display="flex" flexDirection="column" justifyContent="space-between">
-            <TitleBar />
+            <TitleBar avatarAlt={props.avatarAlt} avatarSrc={props.avatarSrc} title={props.title} />
             {props.children}
             <NavigationBar />
         </Box>

--- a/client/src/shell/NavigationBar.tsx
+++ b/client/src/shell/NavigationBar.tsx
@@ -3,25 +3,31 @@ import AssignmentIcon from '@material-ui/icons/Assignment';
 import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 //import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'; // TODO js (25.02.2021): Alternative icon for rewards.
 import RedeemIcon from '@material-ui/icons/Redeem';
+import { useState } from "react";
 
 const useStyles = makeStyles({
     navigation: {
-        backgroundColor: "#01579b", // TODO js (25.02.2021): Move color selection to theme?
-        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+        //backgroundColor: "#01579b", // TODO js (25.02.2021): Move color selection to theme?
+        //color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
     },
     action: {
-        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+        //color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
     },
     icon: {
-        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+        //color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
     }
 });
 
 export function NavigationBar() {
     const classes = useStyles();
+    const [value, setValue] = useState(0);
+
+    function handleOnChange(event: React.ChangeEvent<{}>, newValue: any) {
+        setValue(newValue);
+    }
 
     return (
-        <BottomNavigation className={classes.navigation} showLabels>
+        <BottomNavigation className={classes.navigation} value={value} onChange={handleOnChange} showLabels>
             <BottomNavigationAction className={classes.action} label="Ämtli" icon={<AssignmentIcon className={classes.icon} />} />
             <BottomNavigationAction className={classes.action} label="Belohnungen" icon={<RedeemIcon className={classes.icon} />} />
             <BottomNavigationAction className={classes.action} label="Profil" icon={<AssignmentIndIcon className={classes.icon} />} />

--- a/client/src/shell/NavigationBar.tsx
+++ b/client/src/shell/NavigationBar.tsx
@@ -29,8 +29,8 @@ export function NavigationBar() {
     return (
         <BottomNavigation className={classes.navigation} value={value} onChange={handleOnChange} showLabels>
             <BottomNavigationAction className={classes.action} label="Ämtli" icon={<AssignmentIcon className={classes.icon} />} />
-            <BottomNavigationAction className={classes.action} label="Belohnungen" icon={<RedeemIcon className={classes.icon} />} />
-            <BottomNavigationAction className={classes.action} label="Profil" icon={<AssignmentIndIcon className={classes.icon} />} />
+            <BottomNavigationAction className={classes.action} label="Belohnungen" icon={<RedeemIcon className={classes.icon} />} disabled />
+            <BottomNavigationAction className={classes.action} label="Profil" icon={<AssignmentIndIcon className={classes.icon} />} disabled />
         </BottomNavigation>
     );
 }

--- a/client/src/shell/NavigationBar.tsx
+++ b/client/src/shell/NavigationBar.tsx
@@ -1,0 +1,3 @@
+export function NavigationBar() {
+    return <p>NavigationBar</p>
+}

--- a/client/src/shell/NavigationBar.tsx
+++ b/client/src/shell/NavigationBar.tsx
@@ -3,7 +3,8 @@ import AssignmentIcon from '@material-ui/icons/Assignment';
 import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 //import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'; // TODO js (25.02.2021): Alternative icon for rewards.
 import RedeemIcon from '@material-ui/icons/Redeem';
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Link, useRouteMatch } from "react-router-dom";
 
 const useStyles = makeStyles({
     navigation: {
@@ -18,19 +19,62 @@ const useStyles = makeStyles({
     }
 });
 
+const pages = ["chores", "rewards", "profile"];
+
 export function NavigationBar() {
     const classes = useStyles();
-    const [value, setValue] = useState(0);
+    const [value, setValue] = useState<number>();
+    const {path, } = useRouteMatch();
+
+    useEffect(() => {
+        if (path.match(/\/rewards/)) {
+            setValue(1);
+        } else if (path.match(/\/profile/)) {
+            setValue(2);
+        } else if (path.match(/\/chores/)) {
+            setValue(0);
+        } else {
+            setValue(0);
+        }
+    }, [path]);
 
     function handleOnChange(event: React.ChangeEvent<{}>, newValue: any) {
         setValue(newValue);
     }
 
+    function getPath(): string {
+        const pathParts = path.split("/");
+
+        return pathParts.filter(part => !pages.includes(part)).join("/");
+    }
+
     return (
-        <BottomNavigation className={classes.navigation} value={value} onChange={handleOnChange} showLabels>
-            <BottomNavigationAction className={classes.action} label="Ämtli" icon={<AssignmentIcon className={classes.icon} />} />
-            <BottomNavigationAction className={classes.action} label="Belohnungen" icon={<RedeemIcon className={classes.icon} />} disabled />
-            <BottomNavigationAction className={classes.action} label="Profil" icon={<AssignmentIndIcon className={classes.icon} />} disabled />
+        <BottomNavigation 
+            className={classes.navigation}
+            value={value} 
+            onChange={handleOnChange} 
+            showLabels>
+            <BottomNavigationAction 
+                className={classes.action} 
+                label="Ämtli" 
+                icon={<AssignmentIcon className={classes.icon}/>}
+                component={Link}
+                to={`${getPath()}/chores`}
+            />
+            <BottomNavigationAction 
+                className={classes.action} 
+                label="Belohnungen" 
+                icon={<RedeemIcon className={classes.icon} />}
+                component={Link}
+                to={`${getPath()}/rewards`}
+            />
+            <BottomNavigationAction 
+                className={classes.action} 
+                label="Profil" 
+                icon={<AssignmentIndIcon className={classes.icon} />}
+                component={Link}
+                to={`${getPath()}/profile`}
+            />
         </BottomNavigation>
     );
 }

--- a/client/src/shell/NavigationBar.tsx
+++ b/client/src/shell/NavigationBar.tsx
@@ -1,3 +1,30 @@
+import { BottomNavigation, BottomNavigationAction, makeStyles } from "@material-ui/core";
+import AssignmentIcon from '@material-ui/icons/Assignment';
+import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
+//import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'; // TODO js (25.02.2021): Alternative icon for rewards.
+import RedeemIcon from '@material-ui/icons/Redeem';
+
+const useStyles = makeStyles({
+    navigation: {
+        backgroundColor: "#01579b", // TODO js (25.02.2021): Move color selection to theme?
+        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+    },
+    action: {
+        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+    },
+    icon: {
+        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+    }
+});
+
 export function NavigationBar() {
-    return <p>NavigationBar</p>
+    const classes = useStyles();
+
+    return (
+        <BottomNavigation className={classes.navigation} showLabels>
+            <BottomNavigationAction className={classes.action} label="Ämtli" icon={<AssignmentIcon className={classes.icon} />} />
+            <BottomNavigationAction className={classes.action} label="Belohnungen" icon={<RedeemIcon className={classes.icon} />} />
+            <BottomNavigationAction className={classes.action} label="Profil" icon={<AssignmentIndIcon className={classes.icon} />} />
+        </BottomNavigation>
+    );
 }

--- a/client/src/shell/TitleBar.tsx
+++ b/client/src/shell/TitleBar.tsx
@@ -1,3 +1,33 @@
-export function TitleBar() {
-    return <p>Title Bar</p>;
+import { Avatar, IconButton, makeStyles, Toolbar, Typography } from "@material-ui/core";
+
+const useStyles = makeStyles({
+    toolbar: {
+        backgroundColor: "#01579b", // TODO js (25.02.2021): Move color selection to theme?
+        color: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+    },
+    avatar: {
+        backgroundColor: "#fff", // TODO js (25.02.2021): Move color selection to theme?
+        color: "#000", // TODO js (25.02.2021): Move color selection to theme?
+    },
+    title: {
+        padding: "0px 16px 0px 16px",
+    }
+});
+
+type Prop = {
+    avatarSrc: string;
+    avatarAlt: string;
+    title: string;
+}
+
+export function TitleBar(props: Prop) {
+    const classes = useStyles();
+
+    return (
+        <Toolbar className={classes.toolbar}>
+            <Avatar className={classes.avatar} alt={props.avatarAlt} src={props.avatarSrc} />
+            <Typography className={classes.title} variant="h6">{props.title}</Typography>
+            <IconButton />
+        </Toolbar>
+    );
 }

--- a/client/src/shell/TitleBar.tsx
+++ b/client/src/shell/TitleBar.tsx
@@ -1,0 +1,3 @@
+export function TitleBar() {
+    return <p>Title Bar</p>;
+}


### PR DESCRIPTION
Dieser Pull Request basiert auf [Erste Implementation der Ämtli-View auf dem Eltern Dashboard](https://github.com/TashunkoWitko/MarbleCollector/pull/4) und sollte daher erst nach diesem bearbeitet werden.

- Verwendung von Routen für die Screen-Unterscheidung im Eltern-Dashboard.
- Sichergestellt, dass das korrekte Icon in der NavigationBar als aktiv markiert ist (basierend auf dem aktuellen Pfad).