### PR TITLE
Introduced custom hooks to simplify the use of notifications.

### DIFF
--- a/client/src/Snackbar.tsx
+++ b/client/src/Snackbar.tsx
@@ -3,7 +3,7 @@ import Snackbar from "@material-ui/core/Snackbar";
 import MuiAlert, { AlertProps } from "@material-ui/lab/Alert";
 import Box from "@material-ui/core/Box";
 import { makeStyles, Theme } from "@material-ui/core/styles";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { AppState } from "./AppState";
 
 function Alert(props: AlertProps) {
@@ -49,4 +49,40 @@ export function ShowSnack() {
       </Snackbar>
     </Box>
   );
+}
+
+export function useInfoNotification(): (message: string) => void {
+  const setSnackState = useSetRecoilState(AppState.snackState);
+
+  return (message: string): void => {
+    setSnackState({
+      open: true,
+      message: message,
+      severity: "info",
+    });
+  };
+}
+
+export function useSuccessNotification(): (message: string) => void {
+  const setSnackState = useSetRecoilState(AppState.snackState);
+
+  return (message: string): void => {
+    setSnackState({
+      open: true,
+      message: message,
+      severity: "success",
+    });
+  };
+}
+
+export function useErrorNotification(): (message: string) => void {
+  const setSnackState = useSetRecoilState(AppState.snackState);
+
+  return (message: string): void => {
+    setSnackState({
+      open: true,
+      message: message,
+      severity: "error",
+    });
+  };
 }

--- a/client/src/parent/ChoreTable.tsx
+++ b/client/src/parent/ChoreTable.tsx
@@ -19,10 +19,11 @@ import ErrorIcon from "@material-ui/icons/Error";
 import { ChoreWithAssignments } from "./models/ChoreWithAssignments";
 import { useQuery } from "react-query";
 import axios from "axios";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import { AppState } from "../AppState";
 import { AddChoreDialog } from "./AddChoreDialog";
 import { useState } from "react";
+import { useInfoNotification, useSuccessNotification } from "../Snackbar";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -42,8 +43,8 @@ const apiBaseUrl = process.env.REACT_APP_APIBASEURL as string;
 export function ChoreTable(): JSX.Element {
   const classes = useStyles();
   const [showDialog, setShowDialog] = useState(false);
-
-  const [snack, setSnackState] = useRecoilState(AppState.snackState);
+  const showInfo = useInfoNotification();
+  const showSuccess = useSuccessNotification();
   const bearerToken = useRecoilValue(AppState.userBearerToken);
   const { isLoading, error, data: chores } = useQuery("parentChoreData", () =>
     axios
@@ -72,30 +73,18 @@ export function ChoreTable(): JSX.Element {
     ); // TODO js (04.03.2021): Implement more sophisticated error screen. Refactor to general error screen?
 
   function handleOnCancel() {
-    setSnackState({
-      open: true,
-      message: "abgebrochen",
-      severity: "info",
-    });
+    showInfo("abgebrochen");
     setShowDialog(false); // TODO js (02.03.2021): Replace dummy implementation with correct cancel logic.
   }
 
   function handleOnDelete() {
-    setSnackState({
-      open: true,
-      message: "Ämtli gelöscht",
-      severity: "info",
-    });
+    showInfo("Ämtli gelöscht");
     setShowDialog(false); // TODO js (02.03.2021): Replace dummy implementation with correct delete logic.
   }
 
   function handleOnSave(ChoreObject: object) {
     alert(JSON.stringify(ChoreObject, null, 2));
-    setSnackState({
-      open: true,
-      message: "Ämtli erstellt",
-      severity: "success",
-    });
+    showSuccess("Ämtli erstellt");
     setShowDialog(false); // TODO js (02.03.2021): Replace dummy implementation with correct save logic.
   }
 


### PR DESCRIPTION
Ein Beispiel für den Einsatz von Custom Hooks.
Mit diesen drei separaten Custom Hooks muss der Benutzer erstens nichts über AppState wissen und auch der Parameter für die Übergabe ist kein Objekt mehr, sondern einfach nur noch ein String.

Ich habe die Custom Hooks ins File der Snackbar Komponente mit rein gepackt, da ich das Gefühl hatte, dass diese zusammengehören. Man könnte sich aber noch überlegen diese in ein/mehrere separate Files auszulagern.