### PR TITLE
Titel, Datum, Beschreibung und Wert eines Ämtlis lassen sich jetzt editieren

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -56,6 +56,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 - `npm install react-query`
 - `npm install xlsx`
 - `npm install immer`
+- `npm install yup`
 
 ## Code formatting
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2405,6 +2405,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -10596,6 +10601,11 @@
         "big-integer": "^1.6.16"
       }
     },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+    },
     "nanoid": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -12550,6 +12560,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "property-expr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -15142,6 +15157,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+    },
     "tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -17125,6 +17145,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "yup": {
+      "version": "0.32.9",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.9.tgz",
+      "integrity": "sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@types/lodash": "^4.14.165",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.15",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,8 @@
     "recoil-persist": "^2.3.0",
     "typescript": "^4.1.5",
     "web-vitals": "^1.1.0",
-    "xlsx": "^0.16.9"
+    "xlsx": "^0.16.9",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.1.7"

--- a/client/src/parent/BiAvatarCardHeader.tsx
+++ b/client/src/parent/BiAvatarCardHeader.tsx
@@ -1,6 +1,7 @@
-import { Avatar, Badge, Box, CardHeader, Typography } from "@material-ui/core";
+import { Avatar, Badge, CardHeader } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import { MouseEventHandler } from "react";
+import { EditableText } from "./EditableText";
 
 type Prop = {
   leftAvatarLabel: string;
@@ -10,9 +11,9 @@ type Prop = {
   rightAvatarNotifications: number;
   onRightAvatarClick?: MouseEventHandler<HTMLDivElement>;
   title: string;
-  onTitleClick?: MouseEventHandler<HTMLDivElement>;
+  onTitleChanged?: (newText: string) => void;
   subtitle?: string;
-  onSubtitleClick?: MouseEventHandler<HTMLDivElement>;
+  onSubtitleChanged?: (newText: string) => void;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -40,9 +41,7 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
         </Badge>
       }
       title={
-        <Box onClick={props.onTitleClick}>
-          <Typography variant="body2">{props.title}</Typography>
-        </Box>
+        <EditableText text={props.title} onTextChanged={props.onTitleChanged} />
       }
       action={
         <Badge
@@ -59,9 +58,12 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
         </Badge>
       }
       subheader={
-        <Box onClick={props.onSubtitleClick}>
-          <Typography variant="body2">{props.subtitle}</Typography>
-        </Box>
+        props.subtitle ? (
+          <EditableText
+            text={props.subtitle}
+            onTextChanged={props.onSubtitleChanged}
+          />
+        ) : null
       }
     />
   );

--- a/client/src/parent/BiAvatarCardHeader.tsx
+++ b/client/src/parent/BiAvatarCardHeader.tsx
@@ -3,9 +3,7 @@ import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import { MouseEventHandler } from "react";
 
 type Prop = {
-  leftAvatarLabel: string;
-  leftAvatarNotifications: number;
-  onLeftAvatarClick?: MouseEventHandler<HTMLDivElement>;
+  leftAvatarComponent: JSX.Element;
   rightAvatarLabel: string;
   rightAvatarNotifications: number;
   onRightAvatarClick?: MouseEventHandler<HTMLDivElement>;
@@ -30,13 +28,7 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
   return (
     <CardHeader
       className={classes.header}
-      avatar={
-        <Badge badgeContent={props.leftAvatarNotifications} color="secondary">
-          <Avatar className={classes.avatar} onClick={props.onLeftAvatarClick}>
-            {props.leftAvatarLabel}
-          </Avatar>
-        </Badge>
-      }
+      avatar={props.leftAvatarComponent}
       title={props.titleComponent}
       action={
         <Badge

--- a/client/src/parent/BiAvatarCardHeader.tsx
+++ b/client/src/parent/BiAvatarCardHeader.tsx
@@ -1,7 +1,6 @@
 import { Avatar, Badge, CardHeader } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import { MouseEventHandler } from "react";
-import { EditableText } from "./EditableText";
 
 type Prop = {
   leftAvatarLabel: string;
@@ -10,10 +9,8 @@ type Prop = {
   rightAvatarLabel: string;
   rightAvatarNotifications: number;
   onRightAvatarClick?: MouseEventHandler<HTMLDivElement>;
-  title: string;
-  onTitleChanged?: (newText: string) => void;
-  subtitle?: string;
-  onSubtitleChanged?: (newText: string) => void;
+  titleComponent: JSX.Element;
+  subtitleComponent?: JSX.Element;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -40,9 +37,7 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
           </Avatar>
         </Badge>
       }
-      title={
-        <EditableText text={props.title} onTextChanged={props.onTitleChanged} />
-      }
+      title={props.titleComponent}
       action={
         <Badge
           badgeContent={props.rightAvatarNotifications}
@@ -57,14 +52,7 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
           </Avatar>
         </Badge>
       }
-      subheader={
-        props.subtitle ? (
-          <EditableText
-            text={props.subtitle}
-            onTextChanged={props.onSubtitleChanged}
-          />
-        ) : null
-      }
+      subheader={props.subtitleComponent ? props.subtitleComponent : null}
     />
   );
 }

--- a/client/src/parent/BiAvatarCardHeader.tsx
+++ b/client/src/parent/BiAvatarCardHeader.tsx
@@ -1,12 +1,9 @@
-import { Avatar, Badge, CardHeader } from "@material-ui/core";
+import { CardHeader } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { MouseEventHandler } from "react";
 
 type Prop = {
   leftAvatarComponent: JSX.Element;
-  rightAvatarLabel: string;
-  rightAvatarNotifications: number;
-  onRightAvatarClick?: MouseEventHandler<HTMLDivElement>;
+  rightAvatarComponent: JSX.Element;
   titleComponent: JSX.Element;
   subtitleComponent?: JSX.Element;
 };
@@ -30,20 +27,7 @@ export function BiAvatarCardHeader(props: Prop): JSX.Element {
       className={classes.header}
       avatar={props.leftAvatarComponent}
       title={props.titleComponent}
-      action={
-        <Badge
-          badgeContent={props.rightAvatarNotifications}
-          anchorOrigin={{
-            vertical: "bottom",
-            horizontal: "left",
-          }}
-          color="primary"
-        >
-          <Avatar onClick={props.onRightAvatarClick}>
-            {props.rightAvatarLabel}
-          </Avatar>
-        </Badge>
-      }
+      action={props.rightAvatarComponent}
       subheader={props.subtitleComponent ? props.subtitleComponent : null}
     />
   );

--- a/client/src/parent/EditableDate.tsx
+++ b/client/src/parent/EditableDate.tsx
@@ -9,11 +9,14 @@ import {
 } from "@material-ui/core";
 import { Variant } from "@material-ui/core/styles/createTypography";
 import { Field, Form, Formik } from "formik";
+import { DatePicker } from "formik-material-ui-pickers";
 import { useEffect, useState } from "react";
-import { TextField } from "./TextField";
+import { MuiPickersUtilsProvider } from "@material-ui/pickers";
+import DateFnsUtils from "@date-io/date-fns";
+import { de } from "date-fns/locale";
 
 type Prop = {
-  text: string;
+  date: Date;
   textVariant?: "inherit" | Variant | undefined;
   textColor?:
     | "inherit"
@@ -26,7 +29,7 @@ type Prop = {
     | undefined;
   editLabel: string;
   validationSchema: any;
-  onTextChanged?: (newText: string) => void;
+  onDateChanged?: (newDate: Date) => void;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -40,14 +43,14 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-export function EditableText(props: Prop): JSX.Element {
+export function EditableDate(props: Prop): JSX.Element {
   const classes = useStyles();
-  const [text, setText] = useState("");
+  const [date, setDate] = useState(new Date(Date.now()));
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   useEffect(() => {
-    setText(props.text);
-  }, [props.text]);
+    setDate(props.date);
+  }, [props.date]);
 
   function handleOnClick(event: React.MouseEvent<HTMLButtonElement>) {
     setAnchorEl(event.currentTarget);
@@ -57,36 +60,38 @@ export function EditableText(props: Prop): JSX.Element {
     setAnchorEl(null);
   }
 
-  function handleSubmit(value: string) {
-    setText(value);
+  function handleSubmit(value: Date) {
+    setDate(value);
     handleClose();
-    props.onTextChanged && props.onTextChanged(value);
+    props.onDateChanged && props.onDateChanged(value);
   }
 
   function getForm(): JSX.Element {
     return (
       <Formik
-        initialValues={{ text: text }}
+        initialValues={{ date: date }}
         validationSchema={props.validationSchema}
-        onSubmit={(values) => handleSubmit(values.text)}
+        onSubmit={(values) => handleSubmit(values.date)}
         onReset={handleClose}
       >
-        <Form className={classes.form}>
-          <Box display="flex" flexDirection="column">
-            <Field
-              component={TextField}
-              name="text"
-              type="text"
-              label={props.editLabel}
-            />
-            <Button type="submit" variant="contained" color="primary">
-              Speichern
-            </Button>
-            <Button type="reset" variant="outlined" color="primary">
-              Abbruch
-            </Button>
-          </Box>
-        </Form>
+        <MuiPickersUtilsProvider locale={de} utils={DateFnsUtils}>
+          <Form className={classes.form}>
+            <Box display="flex" flexDirection="column">
+              <Field
+                component={DatePicker}
+                name="date"
+                label={props.editLabel}
+                format="dd.MMMM yy"
+              />
+              <Button type="submit" variant="contained" color="primary">
+                Speichern
+              </Button>
+              <Button type="reset" variant="outlined" color="primary">
+                Abbruch
+              </Button>
+            </Box>
+          </Form>
+        </MuiPickersUtilsProvider>
       </Formik>
     );
   }
@@ -98,7 +103,12 @@ export function EditableText(props: Prop): JSX.Element {
         color={props.textColor ?? "initial"}
         className={classes.text}
       >
-        {text ? text : "Nicht definiert. Text mit Klick hinzufügen."}
+        {new Date(date).toLocaleDateString("de-DE", {
+          weekday: "short",
+          year: "2-digit",
+          month: "short",
+          day: "numeric",
+        })}
       </Typography>
       <Popover
         open={Boolean(anchorEl)}

--- a/client/src/parent/EditableDate.tsx
+++ b/client/src/parent/EditableDate.tsx
@@ -27,6 +27,7 @@ type Prop = {
     | "textPrimary"
     | "error"
     | undefined;
+  editable?: boolean;
   editLabel: string;
   validationSchema: any;
   onDateChanged?: (newDate: Date) => void;
@@ -96,6 +97,10 @@ export function EditableDate(props: Prop): JSX.Element {
     );
   }
 
+  function isOpen(): boolean {
+    return (props.editable ?? false) && Boolean(anchorEl);
+  }
+
   return (
     <Box onClick={handleOnClick}>
       <Typography
@@ -111,7 +116,7 @@ export function EditableDate(props: Prop): JSX.Element {
         })}
       </Typography>
       <Popover
-        open={Boolean(anchorEl)}
+        open={isOpen()}
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorOrigin={{

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -99,7 +99,7 @@ export function EditableText(props: Prop): JSX.Element {
         color={props.textColor ?? "initial"}
         className={classes.text}
       >
-        {text}
+        {text ? text : "Nicht definiert. Text mit Klick hinzufügen."}
       </Typography>
       <Popover
         open={Boolean(anchorEl)}

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -1,25 +1,104 @@
-import { Box, Typography } from "@material-ui/core";
+import {
+  Box,
+  Button,
+  createStyles,
+  makeStyles,
+  Popover,
+  Theme,
+  Typography,
+} from "@material-ui/core";
+import { ErrorMessage, Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
+import * as Yup from "yup";
+import { TextField } from "./TextField";
 
 type Prop = {
   text: string;
   onTextChanged?: (newText: string) => void;
 };
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    form: {
+      padding: theme.spacing(2),
+    },
+  })
+);
+
 export function EditableText(props: Prop): JSX.Element {
+  const classes = useStyles();
   const [text, setText] = useState("");
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     setText(props.text);
   }, [props.text]);
 
-  function handleOnClick() {
-    props.onTextChanged && props.onTextChanged(text); // TODO js (17.03.2021): Replace dummy implementation!
+  function handleOnClick(event: React.MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  function handleSubmit(value: string) {
+    setText(value);
+    handleClose();
+    props.onTextChanged && props.onTextChanged(value);
+  }
+
+  function getForm(): JSX.Element {
+    return (
+      <Formik
+        initialValues={{ text: text }}
+        validationSchema={Yup.object({
+          text: Yup.string()
+            .required("Bitte definieren") // TODO js (17.03.2021): Use parameter.
+            .max(50, "Maximum 50 Zeichen"), // TODO js (17.03.2021): Use parameter.
+        })}
+        onSubmit={(values) => handleSubmit(values.text)}
+        onReset={handleClose}
+      >
+        <Form className={classes.form}>
+          <Box display="flex" flexDirection="column">
+            <Field
+              component={TextField}
+              name="text"
+              type="text"
+              label="Label"
+            />
+            <ErrorMessage name="text" />
+            <Button type="submit" variant="contained" color="primary">
+              Speichern
+            </Button>
+            <Button type="reset" variant="outlined" color="primary">
+              Abbruch
+            </Button>
+          </Box>
+        </Form>
+      </Formik>
+    );
   }
 
   return (
     <Box onClick={handleOnClick}>
       <Typography variant="body2">{text}</Typography>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        {getForm()}
+      </Popover>
     </Box>
   );
 }

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -1,0 +1,25 @@
+import { Box, Typography } from "@material-ui/core";
+import { useEffect, useState } from "react";
+
+type Prop = {
+  text: string;
+  onTextChanged?: (newText: string) => void;
+};
+
+export function EditableText(props: Prop): JSX.Element {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    setText(props.text);
+  }, [props.text]);
+
+  function handleOnClick() {
+    props.onTextChanged && props.onTextChanged(text); // TODO js (17.03.2021): Replace dummy implementation!
+  }
+
+  return (
+    <Box onClick={handleOnClick}>
+      <Typography variant="body2">{text}</Typography>
+    </Box>
+  );
+}

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -7,12 +7,23 @@ import {
   Theme,
   Typography,
 } from "@material-ui/core";
+import { Variant } from "@material-ui/core/styles/createTypography";
 import { ErrorMessage, Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
 import { TextField } from "./TextField";
 
 type Prop = {
   text: string;
+  textVariant?: "inherit" | Variant | undefined;
+  textColor?:
+    | "inherit"
+    | "initial"
+    | "textSecondary"
+    | "primary"
+    | "secondary"
+    | "textPrimary"
+    | "error"
+    | undefined;
   editLabel: string;
   validationSchema: any;
   onTextChanged?: (newText: string) => void;
@@ -22,6 +33,9 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     form: {
       padding: theme.spacing(2),
+    },
+    text: {
+      textAlign: "left",
     },
   })
 );
@@ -80,7 +94,13 @@ export function EditableText(props: Prop): JSX.Element {
 
   return (
     <Box onClick={handleOnClick}>
-      <Typography variant="body2">{text}</Typography>
+      <Typography
+        variant={props.textVariant ?? "body2"}
+        color={props.textColor ?? "initial"}
+        className={classes.text}
+      >
+        {text}
+      </Typography>
       <Popover
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -24,6 +24,7 @@ type Prop = {
     | "textPrimary"
     | "error"
     | undefined;
+  editable?: boolean;
   editLabel: string;
   validationSchema: any;
   onTextChanged?: (newText: string) => void;
@@ -91,6 +92,10 @@ export function EditableText(props: Prop): JSX.Element {
     );
   }
 
+  function isOpen(): boolean {
+    return (props.editable ?? false) && Boolean(anchorEl);
+  }
+
   return (
     <Box onClick={handleOnClick}>
       <Typography
@@ -101,7 +106,7 @@ export function EditableText(props: Prop): JSX.Element {
         {text ? text : "Nicht definiert. Text mit Klick hinzufügen."}
       </Typography>
       <Popover
-        open={Boolean(anchorEl)}
+        open={isOpen()}
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorOrigin={{

--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -9,11 +9,12 @@ import {
 } from "@material-ui/core";
 import { ErrorMessage, Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
-import * as Yup from "yup";
 import { TextField } from "./TextField";
 
 type Prop = {
   text: string;
+  editLabel: string;
+  validationSchema: any;
   onTextChanged?: (newText: string) => void;
 };
 
@@ -52,11 +53,7 @@ export function EditableText(props: Prop): JSX.Element {
     return (
       <Formik
         initialValues={{ text: text }}
-        validationSchema={Yup.object({
-          text: Yup.string()
-            .required("Bitte definieren") // TODO js (17.03.2021): Use parameter.
-            .max(50, "Maximum 50 Zeichen"), // TODO js (17.03.2021): Use parameter.
-        })}
+        validationSchema={props.validationSchema}
         onSubmit={(values) => handleSubmit(values.text)}
         onReset={handleClose}
       >
@@ -66,7 +63,7 @@ export function EditableText(props: Prop): JSX.Element {
               component={TextField}
               name="text"
               type="text"
-              label="Label"
+              label={props.editLabel}
             />
             <ErrorMessage name="text" />
             <Button type="submit" variant="contained" color="primary">

--- a/client/src/parent/EditableTextAvatar.tsx
+++ b/client/src/parent/EditableTextAvatar.tsx
@@ -1,0 +1,117 @@
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  createStyles,
+  makeStyles,
+  Popover,
+  Theme,
+} from "@material-ui/core";
+import { Field, Form, Formik } from "formik";
+import { useEffect, useState } from "react";
+import { TextField } from "./TextField";
+
+type Prop = {
+  value: number;
+  editable?: boolean;
+  editLabel: string;
+  validationSchema: any;
+  notifications: number;
+  onValueChanged?: (value: number) => void;
+};
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    form: {
+      padding: theme.spacing(2),
+    },
+    text: {
+      textAlign: "left",
+    },
+  })
+);
+
+export function EditableTextAvatar(props: Prop): JSX.Element {
+  const classes = useStyles();
+  const [value, setValue] = useState(0);
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setValue(props.value);
+  }, [props.value]);
+
+  function handleOnClick(event: React.MouseEvent<HTMLDivElement>) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  function handleSubmit(value: number) {
+    setValue(value);
+    handleClose();
+    props.onValueChanged && props.onValueChanged(value);
+  }
+
+  function getForm(): JSX.Element {
+    return (
+      <Formik
+        initialValues={{ value: value }}
+        validationSchema={props.validationSchema}
+        onSubmit={(values) => handleSubmit(values.value)}
+        onReset={handleClose}
+      >
+        <Form className={classes.form}>
+          <Box display="flex" flexDirection="column">
+            <Field
+              component={TextField}
+              name="value"
+              type="number"
+              label={props.editLabel}
+            />
+            <Button type="submit" variant="contained" color="primary">
+              Speichern
+            </Button>
+            <Button type="reset" variant="outlined" color="primary">
+              Abbruch
+            </Button>
+          </Box>
+        </Form>
+      </Formik>
+    );
+  }
+
+  function isOpen(): boolean {
+    return (props.editable ?? false) && Boolean(anchorEl);
+  }
+
+  return (
+    <Badge
+      badgeContent={props.notifications}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      color="primary"
+    >
+      <Avatar onClick={handleOnClick}>{props.value.toString()}</Avatar>
+      <Popover
+        open={isOpen()}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        {getForm()}
+      </Popover>
+    </Badge>
+  );
+}

--- a/client/src/parent/TextField.tsx
+++ b/client/src/parent/TextField.tsx
@@ -1,0 +1,21 @@
+import { fieldToTextField, TextFieldProps } from "formik-material-ui";
+import { useCallback } from "react";
+import MuiTextField from "@material-ui/core/TextField";
+
+export function TextField(props: TextFieldProps) {
+  const {
+    form: { setFieldValue },
+    field: { name },
+  } = props;
+
+  const onChange = useCallback(
+    (event) => {
+      const { value } = event.target;
+      setFieldValue(name, value);
+      //setFieldValue(name, event.target); // without destructuring the component does not correctly render as soon as a change has happened!
+    },
+    [setFieldValue, name]
+  );
+
+  return <MuiTextField {...fieldToTextField(props)} onChange={onChange} />;
+}

--- a/client/src/parent/TextField.tsx
+++ b/client/src/parent/TextField.tsx
@@ -17,5 +17,7 @@ export function TextField(props: TextFieldProps) {
     [setFieldValue, name]
   );
 
-  return <MuiTextField {...fieldToTextField(props)} onChange={onChange} />;
+  return (
+    <MuiTextField multiline {...fieldToTextField(props)} onChange={onChange} />
+  );
 }

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -1,5 +1,5 @@
 import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
-import { Box, Card, CircularProgress, Typography } from "@material-ui/core";
+import { Card, Typography } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
 import { AssignmentState } from "../models/AssignmentState";
@@ -13,10 +13,10 @@ import { User } from "../models/User";
 import { useInfoNotification } from "../../shell/hooks/SnackbarHooks";
 import { AddChildMenu } from "../AddChildMenu";
 import { useAddAssignment } from "../BackendAccess";
-import ErrorIcon from "@material-ui/icons/Error";
 import { EditableText } from "../EditableText";
 import * as Yup from "yup";
 import { useQueryDelete, useQueryPut } from "../../api/BackendAccess";
+import produce from "immer";
 
 type Prop = {
   chore: ChoreWithAssignments;
@@ -73,15 +73,6 @@ export function ChoreCard(props: Prop): JSX.Element {
     setExpanded((prevExpanded) => !prevExpanded);
   }
 
-  // function handleAddChildClick() {
-  //   console.log("Adding child");
-  //   putChoreMutation.mutate({
-  //     url: "/api/Chores/",
-  //     object: props.chore,
-  //   });
-  //   showInfo(`Adding child to chore '${props.chore.name}'.`); // TODO js (11.03.2021): Replace dummy implementation.
-  // }
-
   function handleAddChildClick(event: React.MouseEvent<HTMLButtonElement>) {
     setShowAddChildAnchor(event.currentTarget);
     setShowAddChild(true);
@@ -129,11 +120,18 @@ export function ChoreCard(props: Prop): JSX.Element {
     handleMoreClose();
   }
 
-  function handleTitleEdit() {
+  function handleTitleEdit(title: string) {
     console.log("Editing title...");
+    var updatedChore = produce(
+      props.chore,
+      (draftChore: ChoreWithAssignments) => {
+        draftChore.name = title;
+      }
+    );
+
     putChoreMutation.mutate({
       url: "/api/Chores/",
-      object: props.chore,
+      object: updatedChore,
     });
     console.log("Title edited.");
     showInfo("Title edited."); // TODO js (11.03.2021): Replace dummy implementation.

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -228,15 +228,26 @@ export function ChoreCard(props: Prop): JSX.Element {
             onDateChanged={handleDueDateEdit}
           />
         }
-        rightAvatarLabel={props.chore.value.toString()}
-        rightAvatarNotifications={
-          props.chore.assignments.filter(
-            (assignment) =>
-              assignment.state === AssignmentState.CheckConfirmed ||
-              assignment.state === AssignmentState.Archived
-          ).length
+        rightAvatarComponent={
+          <Badge
+            badgeContent={
+              props.chore.assignments.filter(
+                (assignment) =>
+                  assignment.state === AssignmentState.CheckConfirmed ||
+                  assignment.state === AssignmentState.Archived
+              ).length
+            }
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "left",
+            }}
+            color="primary"
+          >
+            <Avatar onClick={handleValueEdit}>
+              {props.chore.value.toString()}
+            </Avatar>
+          </Badge>
         }
-        onRightAvatarClick={handleValueEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -17,6 +17,7 @@ import { EditableText } from "../EditableText";
 import * as Yup from "yup";
 import { useQueryDelete, useQueryPut } from "../../api/BackendAccess";
 import produce from "immer";
+import { EditableDate } from "../EditableDate";
 
 type Prop = {
   chore: ChoreWithAssignments;
@@ -31,6 +32,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   })
 );
+
+const yesterday = new Date(Date.now());
+yesterday.setDate(yesterday.getDate() - 1);
 
 export function ChoreCard(props: Prop): JSX.Element {
   const classes = useStyles();
@@ -134,13 +138,20 @@ export function ChoreCard(props: Prop): JSX.Element {
     showInfo("Title edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
-  function handleDueDateEdit() {
+  function handleDueDateEdit(date: Date) {
     console.log("Editing due date...");
+    var updatedChore = produce(
+      props.chore,
+      (draftChore: ChoreWithAssignments) => {
+        draftChore.dueDate = date;
+      }
+    );
+
     putChoreMutation.mutate({
       url: "/api/Chores/",
-      object: props.chore,
+      object: updatedChore,
     });
-    showInfo("Editing due date..."); // TODO js (11.03.2021): Replace dummy implementation.
+    showInfo("Due date edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
   function handleValueEdit() {
@@ -193,20 +204,16 @@ export function ChoreCard(props: Prop): JSX.Element {
           />
         }
         subtitleComponent={
-          <EditableText
-            text={new Date(props.chore.dueDate).toLocaleDateString("de-DE", {
-              weekday: "short",
-              year: "2-digit",
-              month: "short",
-              day: "numeric",
-            })}
+          <EditableDate
+            date={props.chore.dueDate}
             editLabel="Ablaufdatum"
             validationSchema={Yup.object({
-              text: Yup.string()
-                .required("Bitte definieren")
-                .max(50, "Maximum 50 Zeichen"),
+              date: Yup.date().min(
+                yesterday,
+                "Ausgewählter Tag liegt in der Vergangenheit"
+              ),
             })}
-            onTextChanged={handleDueDateEdit}
+            onDateChanged={handleDueDateEdit}
           />
         }
         rightAvatarLabel={props.chore.value.toString()}

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -194,6 +194,7 @@ export function ChoreCard(props: Prop): JSX.Element {
         titleComponent={
           <EditableText
             text={props.chore.name}
+            editable={!cardLocked}
             editLabel="Bezeichnung des Ämtlis"
             validationSchema={Yup.object({
               text: Yup.string()
@@ -206,6 +207,7 @@ export function ChoreCard(props: Prop): JSX.Element {
         subtitleComponent={
           <EditableDate
             date={props.chore.dueDate}
+            editable={!cardLocked}
             editLabel="Ablaufdatum"
             validationSchema={Yup.object({
               date: Yup.date().min(
@@ -243,6 +245,7 @@ export function ChoreCard(props: Prop): JSX.Element {
         <EditableText
           text={props.chore.description}
           textColor="textSecondary"
+          editable={!cardLocked}
           editLabel="Beschreibung des Ämtlis"
           validationSchema={Yup.object({
             text: Yup.string().max(250, "Maximum 250 Zeichen"),

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -113,8 +113,8 @@ export function ChoreCard(props: Prop): JSX.Element {
   }
 
   function handleTitleEdit() {
-    console.log("Editing title...");
-    showInfo("Editing title..."); // TODO js (11.03.2021): Replace dummy implementation.
+    console.log("Title edited.");
+    showInfo("Title edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
   function handleDueDateEdit() {
@@ -185,8 +185,8 @@ export function ChoreCard(props: Prop): JSX.Element {
           ).length
         }
         onRightAvatarClick={handleValueEdit}
-        onTitleClick={handleTitleEdit}
-        onSubtitleClick={handleDueDateEdit}
+        onTitleChanged={handleTitleEdit}
+        onSubtitleChanged={handleDueDateEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -1,5 +1,5 @@
 import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
-import { Card } from "@material-ui/core";
+import { Avatar, Badge, Card } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
 import { AssignmentState } from "../models/AssignmentState";
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) =>
     cardContent: {
       paddingTop: "0px",
       paddingBottom: "8px",
+    },
+    avatar: {
+      backgroundColor: theme.palette.primary.main,
     },
   })
 );
@@ -183,14 +186,21 @@ export function ChoreCard(props: Prop): JSX.Element {
   return (
     <Card elevation={5}>
       <BiAvatarCardHeader
-        leftAvatarLabel={props.chore.assignments.length.toString()}
-        leftAvatarNotifications={
-          props.chore.assignments.filter(
-            (assignment) =>
-              assignment.state === AssignmentState.RequestedToCheck
-          ).length
+        leftAvatarComponent={
+          <Badge
+            badgeContent={
+              props.chore.assignments.filter(
+                (assignment) =>
+                  assignment.state === AssignmentState.RequestedToCheck
+              ).length
+            }
+            color="secondary"
+          >
+            <Avatar className={classes.avatar} onClick={handleExpandClick}>
+              {props.chore.assignments.length.toString()}
+            </Avatar>
+          </Badge>
         }
-        onLeftAvatarClick={handleExpandClick}
         titleComponent={
           <EditableText
             text={props.chore.name}

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -169,22 +169,6 @@ export function ChoreCard(props: Prop): JSX.Element {
     showInfo("Description edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
-  function getDescription() {
-    if (!props.chore.description) return;
-
-    return (
-      <EditableText
-        text={props.chore.description}
-        textColor="textSecondary"
-        editLabel="Beschreibung des Ämtlis"
-        validationSchema={Yup.object({
-          text: Yup.string().max(250, "Maximum 250 Zeichen"),
-        })}
-        onTextChanged={handleDescriptionEdit}
-      />
-    );
-  }
-
   return (
     <Card elevation={5}>
       <BiAvatarCardHeader
@@ -249,7 +233,15 @@ export function ChoreCard(props: Prop): JSX.Element {
         className={classes.cardContent}
         expanded={expanded}
       >
-        {getDescription()}
+        <EditableText
+          text={props.chore.description}
+          textColor="textSecondary"
+          editLabel="Beschreibung des Ämtlis"
+          validationSchema={Yup.object({
+            text: Yup.string().max(250, "Maximum 250 Zeichen"),
+          })}
+          onTextChanged={handleDescriptionEdit}
+        />
         <AssignmentList assignments={props.chore.assignments} />
         <AddButtonWithLabel
           title="Kind hinzufügen"

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -1,7 +1,7 @@
 import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
 import { Box, Card, CircularProgress, Typography } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AssignmentState } from "../models/AssignmentState";
 import { AssignmentList } from "./AssignmentList";
 import { MoreOptionsMenu } from "../MoreOptionsMenu";
@@ -14,6 +14,8 @@ import { useInfoNotification } from "../../shell/hooks/SnackbarHooks";
 import { AddChildMenu } from "../AddChildMenu";
 import { useAddAssignment } from "../BackendAccess";
 import ErrorIcon from "@material-ui/icons/Error";
+import { EditableText } from "../EditableText";
+import * as Yup from "yup";
 
 type Prop = {
   chore: ChoreWithAssignments;
@@ -169,13 +171,35 @@ export function ChoreCard(props: Prop): JSX.Element {
           ).length
         }
         onLeftAvatarClick={handleExpandClick}
-        title={props.chore.name}
-        subtitle={new Date(props.chore.dueDate).toLocaleDateString("de-DE", {
-          weekday: "short",
-          year: "2-digit",
-          month: "short",
-          day: "numeric",
-        })}
+        titleComponent={
+          <EditableText
+            text={props.chore.name}
+            editLabel="Bezeichnung des Ämtlis"
+            validationSchema={Yup.object({
+              text: Yup.string()
+                .required("Bitte definieren")
+                .max(50, "Maximum 50 Zeichen"),
+            })}
+            onTextChanged={handleTitleEdit}
+          />
+        }
+        subtitleComponent={
+          <EditableText
+            text={new Date(props.chore.dueDate).toLocaleDateString("de-DE", {
+              weekday: "short",
+              year: "2-digit",
+              month: "short",
+              day: "numeric",
+            })}
+            editLabel="Ablaufdatum"
+            validationSchema={Yup.object({
+              text: Yup.string()
+                .required("Bitte definieren")
+                .max(50, "Maximum 50 Zeichen"),
+            })}
+            onTextChanged={handleDueDateEdit}
+          />
+        }
         rightAvatarLabel={props.chore.value.toString()}
         rightAvatarNotifications={
           props.chore.assignments.filter(
@@ -185,8 +209,6 @@ export function ChoreCard(props: Prop): JSX.Element {
           ).length
         }
         onRightAvatarClick={handleValueEdit}
-        onTitleChanged={handleTitleEdit}
-        onSubtitleChanged={handleDueDateEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -1,5 +1,5 @@
 import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
-import { Card, Typography } from "@material-ui/core";
+import { Card } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
 import { AssignmentState } from "../models/AssignmentState";
@@ -25,9 +25,6 @@ type Prop = {
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    description: {
-      textAlign: "left",
-    },
     cardContent: {
       paddingTop: "0px",
       paddingBottom: "8px",
@@ -155,18 +152,36 @@ export function ChoreCard(props: Prop): JSX.Element {
     showInfo("Editing amount of marbles..."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
+  function handleDescriptionEdit(description: string) {
+    console.log("Editing description...");
+    var updatedChore = produce(
+      props.chore,
+      (draftChore: ChoreWithAssignments) => {
+        draftChore.description = description;
+      }
+    );
+
+    putChoreMutation.mutate({
+      url: "/api/Chores/",
+      object: updatedChore,
+    });
+    console.log("Description edited.");
+    showInfo("Description edited."); // TODO js (11.03.2021): Replace dummy implementation.
+  }
+
   function getDescription() {
     if (!props.chore.description) return;
 
     return (
-      <Typography
-        className={classes.description}
-        variant="body2"
-        color="textSecondary"
-        component="p"
-      >
-        {props.chore.description}
-      </Typography>
+      <EditableText
+        text={props.chore.description}
+        textColor="textSecondary"
+        editLabel="Beschreibung des Ämtlis"
+        validationSchema={Yup.object({
+          text: Yup.string().max(250, "Maximum 250 Zeichen"),
+        })}
+        onTextChanged={handleDescriptionEdit}
+      />
     );
   }
 

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -18,6 +18,7 @@ import * as Yup from "yup";
 import { useQueryDelete, useQueryPut } from "../../api/BackendAccess";
 import produce from "immer";
 import { EditableDate } from "../EditableDate";
+import { EditableTextAvatar } from "../EditableTextAvatar";
 
 type Prop = {
   chore: ChoreWithAssignments;
@@ -157,13 +158,20 @@ export function ChoreCard(props: Prop): JSX.Element {
     showInfo("Due date edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
-  function handleValueEdit() {
+  function handleValueEdit(value: number) {
     console.log("Editing amount of marbles...");
+    var updatedChore = produce(
+      props.chore,
+      (draftChore: ChoreWithAssignments) => {
+        draftChore.value = value;
+      }
+    );
+
     putChoreMutation.mutate({
       url: "/api/Chores/",
-      object: props.chore,
+      object: updatedChore,
     });
-    showInfo("Editing amount of marbles..."); // TODO js (11.03.2021): Replace dummy implementation.
+    showInfo("Amount of marbles edited."); // TODO js (11.03.2021): Replace dummy implementation.
   }
 
   function handleDescriptionEdit(description: string) {
@@ -229,24 +237,24 @@ export function ChoreCard(props: Prop): JSX.Element {
           />
         }
         rightAvatarComponent={
-          <Badge
-            badgeContent={
+          <EditableTextAvatar
+            value={props.chore.value}
+            editable={!cardLocked}
+            editLabel="Wert in Murmeln"
+            validationSchema={Yup.object({
+              value: Yup.number()
+                .required("Bitte Wert definieren")
+                .min(1, "Wert > 0"),
+            })}
+            notifications={
               props.chore.assignments.filter(
                 (assignment) =>
                   assignment.state === AssignmentState.CheckConfirmed ||
                   assignment.state === AssignmentState.Archived
               ).length
             }
-            anchorOrigin={{
-              vertical: "bottom",
-              horizontal: "left",
-            }}
-            color="primary"
-          >
-            <Avatar onClick={handleValueEdit}>
-              {props.chore.value.toString()}
-            </Avatar>
-          </Badge>
+            onValueChanged={handleValueEdit}
+          />
         }
       />
       <AddOptionsExpandCardActions

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -1,5 +1,12 @@
 import { RewardWithGrants } from "../models/RewardWithGrants";
-import { Box, Card, CircularProgress, Typography } from "@material-ui/core";
+import {
+  Avatar,
+  Badge,
+  Box,
+  Card,
+  CircularProgress,
+  Typography,
+} from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
 import { GrantState } from "../models/GrantState";
@@ -30,6 +37,9 @@ const useStyles = makeStyles((theme: Theme) =>
     cardContent: {
       paddingTop: "0px",
       paddingBottom: "8px",
+    },
+    avatar: {
+      backgroundColor: theme.palette.primary.main,
     },
   })
 );
@@ -157,13 +167,20 @@ export function RewardCard(props: Prop): JSX.Element {
   return (
     <Card elevation={5}>
       <BiAvatarCardHeader
-        leftAvatarLabel={props.reward.grants.length.toString()}
-        leftAvatarNotifications={
-          props.reward.grants.filter(
-            (grant) => grant.state === GrantState.Requested
-          ).length
+        leftAvatarComponent={
+          <Badge
+            badgeContent={
+              props.reward.grants.filter(
+                (grant) => grant.state === GrantState.Requested
+              ).length
+            }
+            color="secondary"
+          >
+            <Avatar className={classes.avatar} onClick={handleExpandClick}>
+              {props.reward.grants.length.toString()}
+            </Avatar>
+          </Badge>
         }
-        onLeftAvatarClick={handleExpandClick}
         titleComponent={
           <EditableText
             text={props.reward.name}

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -1,7 +1,7 @@
 import { RewardWithGrants } from "../models/RewardWithGrants";
 import { Box, Card, CircularProgress, Typography } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { GrantState } from "../models/GrantState";
 import { GrantList } from "./GrantList";
 import { MoreOptionsMenu } from "../MoreOptionsMenu";
@@ -14,6 +14,8 @@ import { useInfoNotification } from "../../shell/hooks/SnackbarHooks";
 import { AddChildMenu } from "../AddChildMenu";
 import { useAddGrant } from "../BackendAccess";
 import ErrorIcon from "@material-ui/icons/Error";
+import { EditableText } from "../EditableText";
+import * as Yup from "yup";
 
 type Prop = {
   reward: RewardWithGrants;
@@ -162,7 +164,18 @@ export function RewardCard(props: Prop): JSX.Element {
           ).length
         }
         onLeftAvatarClick={handleExpandClick}
-        title={props.reward.name}
+        titleComponent={
+          <EditableText
+            text={props.reward.name}
+            editLabel="Bezeichnung der Belohnung"
+            validationSchema={Yup.object({
+              text: Yup.string()
+                .required("Bitte definieren") // TODO js (17.03.2021): Use parameter.
+                .max(50, "Maximum 50 Zeichen"), // TODO js (17.03.2021): Use parameter.
+            })}
+            onTextChanged={handleTitleEdit}
+          />
+        }
         rightAvatarLabel={props.reward.value.toString()}
         rightAvatarNotifications={
           props.reward.grants.filter(
@@ -172,7 +185,6 @@ export function RewardCard(props: Prop): JSX.Element {
           ).length
         }
         onRightAvatarClick={handleValueEdit}
-        onTitleChanged={handleTitleEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -193,15 +193,26 @@ export function RewardCard(props: Prop): JSX.Element {
             onTextChanged={handleTitleEdit}
           />
         }
-        rightAvatarLabel={props.reward.value.toString()}
-        rightAvatarNotifications={
-          props.reward.grants.filter(
-            (grant) =>
-              grant.state === GrantState.RequestConfirmed ||
-              grant.state === GrantState.Archived
-          ).length
+        rightAvatarComponent={
+          <Badge
+            badgeContent={
+              props.reward.grants.filter(
+                (grant) =>
+                  grant.state === GrantState.RequestConfirmed ||
+                  grant.state === GrantState.Archived
+              ).length
+            }
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "left",
+            }}
+            color="primary"
+          >
+            <Avatar onClick={handleValueEdit}>
+              {props.reward.value.toString()}
+            </Avatar>
+          </Badge>
         }
-        onRightAvatarClick={handleValueEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -172,7 +172,7 @@ export function RewardCard(props: Prop): JSX.Element {
           ).length
         }
         onRightAvatarClick={handleValueEdit}
-        onTitleClick={handleTitleEdit}
+        onTitleChanged={handleTitleEdit}
       />
       <AddOptionsExpandCardActions
         addLabel="Kind hinzufügen"


### PR DESCRIPTION
- Entsprechende Editoren als separate Komponenten implementiert.
- Validierung mit Hilfe der Yup Library (auch für Datumsfeld).
- Update-Calls auf Backend werden ausgeführt.
- Ämtli lässt sich nur editieren, wenn noch keine Aktivität durch Kinder erfolgt ist.

**Stringeditor:**
![image](https://user-images.githubusercontent.com/17404505/111739634-a6796900-8883-11eb-9157-7959678d79dd.png)

**Zahleneditor:**
![image](https://user-images.githubusercontent.com/17404505/111739642-aaa58680-8883-11eb-8cfe-1d40eb1ee2af.png)

**Datepicker als Datumseditor:**
![image](https://user-images.githubusercontent.com/17404505/111739647-aed1a400-8883-11eb-8d4f-727d04a8bb5b.png)

**Validierung und Fehlermeldung:**
![image](https://user-images.githubusercontent.com/17404505/111739655-b1cc9480-8883-11eb-87fc-931bd35ae855.png)
