### PR TITLE
Murmel Icon auf Parent Dashboard

### DIFF
--- a/client/src/parent/EditableText.tsx
+++ b/client/src/parent/EditableText.tsx
@@ -103,7 +103,11 @@ export function EditableText(props: Prop): JSX.Element {
         color={props.textColor ?? "initial"}
         className={classes.text}
       >
-        {text ? text : "Nicht definiert. Text mit Klick hinzufügen."}
+        {text
+          ? text
+          : props.editable
+          ? "Nicht definiert. Text mit Klick hinzufügen."
+          : ""}
       </Typography>
       <Popover
         open={isOpen()}

--- a/client/src/parent/EditableTextAvatar.tsx
+++ b/client/src/parent/EditableTextAvatar.tsx
@@ -55,6 +55,10 @@ const useStyles = makeStyles((theme: Theme) =>
       "font-size": "1rem",
       "padding-right": "8px",
     },
+    doneNotificationBadge: {
+      color: "white",
+      backgroundColor: theme.palette.success.light,
+    },
   })
 );
 
@@ -115,12 +119,12 @@ export function EditableTextAvatar(props: Prop): JSX.Element {
 
   return (
     <Badge
+      classes={{ badge: classes.doneNotificationBadge }}
       badgeContent={props.notifications}
       anchorOrigin={{
         vertical: "bottom",
         horizontal: "left",
       }}
-      color="primary"
     >
       <ThemeProvider theme={theme}>
         <Badge

--- a/client/src/parent/EditableTextAvatar.tsx
+++ b/client/src/parent/EditableTextAvatar.tsx
@@ -11,6 +11,8 @@ import {
 import { Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
 import { TextField } from "./TextField";
+import ImgMarbles from "../images/Marble.png";
+import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 
 type Prop = {
   value: number;
@@ -21,6 +23,25 @@ type Prop = {
   onValueChanged?: (value: number) => void;
 };
 
+const theme = createMuiTheme({
+  overrides: {
+    MuiAvatar: {
+      img: {
+        opacity: "0.75",
+      },
+    },
+    MuiBadge: {
+      badge: {
+        "font-weight": "bold",
+        "font-size": "1.25rem",
+      },
+      anchorOriginBottomRightCircle: {
+        transform: "scale(1) translate(40%, 50%)",
+      },
+    },
+  },
+});
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     form: {
@@ -28,6 +49,11 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     text: {
       textAlign: "left",
+    },
+    badgestyle: {
+      "font-weight": "Bold",
+      "font-size": "1rem",
+      "padding-right": "8px",
     },
   })
 );
@@ -96,7 +122,21 @@ export function EditableTextAvatar(props: Prop): JSX.Element {
       }}
       color="primary"
     >
-      <Avatar onClick={handleOnClick}>{props.value.toString()}</Avatar>
+      <ThemeProvider theme={theme}>
+        <Badge
+          onClick={handleOnClick}
+          overlap="circle"
+          className={classes.badgestyle}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "right",
+          }}
+          badgeContent={props.value}
+        >
+          <Avatar src={ImgMarbles}>{props.value.toString()}</Avatar>
+        </Badge>
+      </ThemeProvider>
+
       <Popover
         open={isOpen()}
         anchorEl={anchorEl}

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -39,6 +39,10 @@ const useStyles = makeStyles((theme: Theme) =>
     avatar: {
       backgroundColor: theme.palette.primary.main,
     },
+    actionNotificationBadge: {
+      color: "white",
+      backgroundColor: theme.palette.warning.light,
+    },
   })
 );
 
@@ -179,15 +183,16 @@ export function ChoreCard(props: Prop): JSX.Element {
       <BiAvatarCardHeader
         leftAvatarComponent={
           <Badge
+            classes={{ badge: classes.actionNotificationBadge }}
             badgeContent={
               props.chore.assignments.filter(
                 (assignment) =>
                   assignment.state === AssignmentState.RequestedToCheck
               ).length
             }
-            color="secondary"
+            onClick={handleExpandClick}
           >
-            <Avatar className={classes.avatar} onClick={handleExpandClick}>
+            <Avatar className={classes.avatar}>
               {props.chore.assignments.length.toString()}
             </Avatar>
           </Badge>

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -41,6 +41,10 @@ const useStyles = makeStyles((theme: Theme) =>
     avatar: {
       backgroundColor: theme.palette.primary.main,
     },
+    actionNotificationBadge: {
+      color: "white",
+      backgroundColor: theme.palette.warning.light,
+    },
   })
 );
 
@@ -166,14 +170,15 @@ export function RewardCard(props: Prop): JSX.Element {
       <BiAvatarCardHeader
         leftAvatarComponent={
           <Badge
+            classes={{ badge: classes.actionNotificationBadge }}
             badgeContent={
               props.reward.grants.filter(
                 (grant) => grant.state === GrantState.Requested
               ).length
             }
-            color="secondary"
+            onClick={handleExpandClick}
           >
-            <Avatar className={classes.avatar} onClick={handleExpandClick}>
+            <Avatar className={classes.avatar}>
               {props.reward.grants.length.toString()}
             </Avatar>
           </Badge>


### PR DESCRIPTION
- Murmel Icon wird jetzt auch auf Parent Dashboard verwendet.
- Farben der Badges auf den Card-Headern für Ämtli und Belohnungen angepasst.
![image](https://user-images.githubusercontent.com/17404505/112509305-a223e300-8d90-11eb-9b31-3b549e3fc80d.png)

- Hinweistext für fehlende Beschreibung wird nicht mehr angezeigt, wenn Ämtli/Belohnung nicht bearbeitet werden kann.
![image](https://user-images.githubusercontent.com/17404505/112509438-bff14800-8d90-11eb-870a-0f744af90578.png)
