### PR TITLE
Sortierung der Ämtli/Belohnungen nach Aktualität

### DIFF
--- a/api/MarbleCollectorApi/Controllers/ChoresController.cs
+++ b/api/MarbleCollectorApi/Controllers/ChoresController.cs
@@ -56,7 +56,7 @@ namespace MarbleCollectorApi.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public ActionResult<Chore> CreateChore(Chore chore)
         {
-            if (string.IsNullOrEmpty(chore.Name) || string.IsNullOrEmpty(chore.Description))
+            if (string.IsNullOrEmpty(chore.Name))
             {
                 return BadRequest();
             }

--- a/api/MarbleCollectorApi/Controllers/RewardsController.cs
+++ b/api/MarbleCollectorApi/Controllers/RewardsController.cs
@@ -56,7 +56,7 @@ namespace MarbleCollectorApi.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public ActionResult<Reward> CreateReward(Reward reward)
         {
-            if (string.IsNullOrEmpty(reward.Name) || string.IsNullOrEmpty(reward.Description))
+            if (string.IsNullOrEmpty(reward.Name))
             {
                 return BadRequest();
             }

--- a/client/src/parent/chores/ChoreCard.tsx
+++ b/client/src/parent/chores/ChoreCard.tsx
@@ -2,7 +2,11 @@ import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
 import { Avatar, Badge, Card } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
-import { AssignmentState } from "../models/AssignmentState";
+import {
+  AssignmentState,
+  isDone,
+  isParentActionNeeded,
+} from "../models/AssignmentState";
 import { AssignmentList } from "./AssignmentList";
 import { MoreOptionsMenu } from "../MoreOptionsMenu";
 import { AddOptionsExpandCardActions } from "../AddOptionsExpandCardActions";
@@ -185,9 +189,8 @@ export function ChoreCard(props: Prop): JSX.Element {
           <Badge
             classes={{ badge: classes.actionNotificationBadge }}
             badgeContent={
-              props.chore.assignments.filter(
-                (assignment) =>
-                  assignment.state === AssignmentState.RequestedToCheck
+              props.chore.assignments.filter((assignment) =>
+                isParentActionNeeded(assignment.state)
               ).length
             }
             onClick={handleExpandClick}
@@ -237,10 +240,8 @@ export function ChoreCard(props: Prop): JSX.Element {
                 .min(1, "Wert > 0"),
             })}
             notifications={
-              props.chore.assignments.filter(
-                (assignment) =>
-                  assignment.state === AssignmentState.CheckConfirmed ||
-                  assignment.state === AssignmentState.Archived
+              props.chore.assignments.filter((assignment) =>
+                isDone(assignment.state)
               ).length
             }
             onValueChanged={handleValueEdit}

--- a/client/src/parent/chores/ChoreList.tsx
+++ b/client/src/parent/chores/ChoreList.tsx
@@ -18,7 +18,10 @@ import {
   useParentChoreLoader,
   useParentChorePost,
 } from "../../api/BackendAccess";
-import { ChoreWithAssignments } from "../models/ChoreWithAssignments";
+import {
+  ChoreWithAssignments,
+  compareChores,
+} from "../models/ChoreWithAssignments";
 import { useMyNotificationsByNamePrefixWithHandle } from "../../notifications/NotificationHooks";
 import { NotificationNames } from "../../notifications/NotificationNames";
 import produce from "immer";
@@ -94,14 +97,17 @@ export function ChoreList(): JSX.Element {
   return (
     <Box className={classes.container} component={Paper}>
       <List>
-        {chores?.map((chore) => (
-          <ChoreCard
-            key={chore.id}
-            chore={chore}
-            children={children ?? []}
-            onCopyChore={handleCopyChore}
-          />
-        ))}
+        {chores
+          ?.sort(compareChores)
+          .reverse()
+          .map((chore) => (
+            <ChoreCard
+              key={chore.id}
+              chore={chore}
+              children={children ?? []}
+              onCopyChore={handleCopyChore}
+            />
+          ))}
       </List>
       <Fab
         className={classes.fab}

--- a/client/src/parent/chores/ChoreList.tsx
+++ b/client/src/parent/chores/ChoreList.tsx
@@ -99,7 +99,7 @@ export function ChoreList(): JSX.Element {
       <List>
         {chores
           ?.sort(compareChores)
-          .reverse()
+          .reverse() // sort descending
           .map((chore) => (
             <ChoreCard
               key={chore.id}

--- a/client/src/parent/models/AssignmentState.ts
+++ b/client/src/parent/models/AssignmentState.ts
@@ -15,3 +15,14 @@ export const AssignmentStateNames = [
   "abgelehnt",
   "erledigt",
 ];
+
+export function isParentActionNeeded(state: AssignmentState): boolean {
+  return state === AssignmentState.RequestedToCheck;
+}
+
+export function isDone(state: AssignmentState): boolean {
+  return (
+    state === AssignmentState.CheckConfirmed ||
+    state === AssignmentState.Archived
+  );
+}

--- a/client/src/parent/models/ChoreWithAssignments.ts
+++ b/client/src/parent/models/ChoreWithAssignments.ts
@@ -42,5 +42,5 @@ export function compareChores(
   const assignmentComparison = compareAssignments(a.assignments, b.assignments);
   if (assignmentComparison !== 0) return assignmentComparison;
 
-  return a.name.localeCompare(b.name);
+  return b.name.localeCompare(a.name);
 }

--- a/client/src/parent/models/ChoreWithAssignments.ts
+++ b/client/src/parent/models/ChoreWithAssignments.ts
@@ -1,4 +1,5 @@
 import { Assignment } from "./Assignment";
+import { isParentActionNeeded } from "./AssignmentState";
 
 export interface ChoreWithAssignments {
   id: number;
@@ -9,19 +10,29 @@ export interface ChoreWithAssignments {
   assignments: Assignment[];
 }
 
+function maxTime(assignments: Assignment[]): number {
+  return Math.max(
+    ...assignments.map((item) =>
+      item.modified ? new Date(item.modified).getTime() : 0
+    )
+  );
+}
+
 function compareAssignments(a: Assignment[], b: Assignment[]): number {
   if (a.length === 0 || b.length === 0) {
     return a.length - b.length;
   }
 
-  const aInMs = Math.max(
-    ...a.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
-  );
-  const bInMs = Math.max(
-    ...b.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
-  );
+  const aActive = a.filter((item) => isParentActionNeeded(item.state));
+  const bActive = b.filter((item) => isParentActionNeeded(item.state));
 
-  return aInMs - bInMs;
+  if (aActive.length !== bActive.length) return aActive.length - bActive.length;
+
+  const activeTimeComparison = maxTime(aActive) - maxTime(bActive);
+
+  if (activeTimeComparison !== 0) return activeTimeComparison;
+
+  return maxTime(a) - maxTime(b);
 }
 
 export function compareChores(

--- a/client/src/parent/models/ChoreWithAssignments.ts
+++ b/client/src/parent/models/ChoreWithAssignments.ts
@@ -8,3 +8,28 @@ export interface ChoreWithAssignments {
   dueDate: Date;
   assignments: Assignment[];
 }
+
+function compareAssignments(a: Assignment[], b: Assignment[]): number {
+  if (a.length === 0 || b.length === 0) {
+    return a.length - b.length;
+  }
+
+  const aInMs = Math.max(
+    ...a.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
+  );
+  const bInMs = Math.max(
+    ...b.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
+  );
+
+  return aInMs - bInMs;
+}
+
+export function compareChores(
+  a: ChoreWithAssignments,
+  b: ChoreWithAssignments
+): number {
+  const assignmentComparison = compareAssignments(a.assignments, b.assignments);
+  if (assignmentComparison !== 0) return assignmentComparison;
+
+  return a.name.localeCompare(b.name);
+}

--- a/client/src/parent/models/GrantState.ts
+++ b/client/src/parent/models/GrantState.ts
@@ -13,3 +13,11 @@ export const GrantStateNames = [
   "abgelehnt",
   "erledigt",
 ];
+
+export function isParentActionNeeded(state: GrantState): boolean {
+  return state === GrantState.Requested;
+}
+
+export function isDone(state: GrantState): boolean {
+  return state === GrantState.RequestConfirmed || state === GrantState.Archived;
+}

--- a/client/src/parent/models/RewardWithGrants.ts
+++ b/client/src/parent/models/RewardWithGrants.ts
@@ -41,5 +41,5 @@ export function compareChores(
   const grantComparison = compareGrants(a.grants, b.grants);
   if (grantComparison !== 0) return grantComparison;
 
-  return a.name.localeCompare(b.name);
+  return b.name.localeCompare(a.name);
 }

--- a/client/src/parent/models/RewardWithGrants.ts
+++ b/client/src/parent/models/RewardWithGrants.ts
@@ -7,3 +7,28 @@ export interface RewardWithGrants {
   value: number;
   grants: Grant[];
 }
+
+function compareGrants(a: Grant[], b: Grant[]): number {
+  if (a.length === 0 || b.length === 0) {
+    return a.length - b.length;
+  }
+
+  const aInMs = Math.max(
+    ...a.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
+  );
+  const bInMs = Math.max(
+    ...b.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
+  );
+
+  return aInMs - bInMs;
+}
+
+export function compareChores(
+  a: RewardWithGrants,
+  b: RewardWithGrants
+): number {
+  const grantComparison = compareGrants(a.grants, b.grants);
+  if (grantComparison !== 0) return grantComparison;
+
+  return a.name.localeCompare(b.name);
+}

--- a/client/src/parent/models/RewardWithGrants.ts
+++ b/client/src/parent/models/RewardWithGrants.ts
@@ -1,4 +1,5 @@
 import { Grant } from "./Grant";
+import { isParentActionNeeded } from "./GrantState";
 
 export interface RewardWithGrants {
   id: number;
@@ -8,19 +9,29 @@ export interface RewardWithGrants {
   grants: Grant[];
 }
 
+function maxTime(grants: Grant[]): number {
+  return Math.max(
+    ...grants.map((item) =>
+      item.modified ? new Date(item.modified).getTime() : 0
+    )
+  );
+}
+
 function compareGrants(a: Grant[], b: Grant[]): number {
   if (a.length === 0 || b.length === 0) {
     return a.length - b.length;
   }
 
-  const aInMs = Math.max(
-    ...a.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
-  );
-  const bInMs = Math.max(
-    ...b.map((item) => (item.modified ? new Date(item.modified).getTime() : 0))
-  );
+  const aActive = a.filter((item) => isParentActionNeeded(item.state));
+  const bActive = b.filter((item) => isParentActionNeeded(item.state));
 
-  return aInMs - bInMs;
+  if (aActive.length !== bActive.length) return aActive.length - bActive.length;
+
+  const activeTimeComparison = maxTime(aActive) - maxTime(bActive);
+
+  if (activeTimeComparison !== 0) return activeTimeComparison;
+
+  return maxTime(a) - maxTime(b);
 }
 
 export function compareChores(

--- a/client/src/parent/rewards/RewardCard.tsx
+++ b/client/src/parent/rewards/RewardCard.tsx
@@ -2,7 +2,7 @@ import { RewardWithGrants } from "../models/RewardWithGrants";
 import { Avatar, Badge, Card } from "@material-ui/core";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import React, { useEffect, useState } from "react";
-import { GrantState } from "../models/GrantState";
+import { GrantState, isDone, isParentActionNeeded } from "../models/GrantState";
 import { GrantList } from "./GrantList";
 import { MoreOptionsMenu } from "../MoreOptionsMenu";
 import { AddOptionsExpandCardActions } from "../AddOptionsExpandCardActions";
@@ -172,8 +172,8 @@ export function RewardCard(props: Prop): JSX.Element {
           <Badge
             classes={{ badge: classes.actionNotificationBadge }}
             badgeContent={
-              props.reward.grants.filter(
-                (grant) => grant.state === GrantState.Requested
+              props.reward.grants.filter((grant) =>
+                isParentActionNeeded(grant.state)
               ).length
             }
             onClick={handleExpandClick}
@@ -208,11 +208,7 @@ export function RewardCard(props: Prop): JSX.Element {
                 .min(1, "Wert > 0"),
             })}
             notifications={
-              props.reward.grants.filter(
-                (grant) =>
-                  grant.state === GrantState.RequestConfirmed ||
-                  grant.state === GrantState.Archived
-              ).length
+              props.reward.grants.filter((grant) => isDone(grant.state)).length
             }
             onValueChanged={handleValueEdit}
           />

--- a/client/src/parent/rewards/RewardsList.tsx
+++ b/client/src/parent/rewards/RewardsList.tsx
@@ -97,7 +97,7 @@ export function RewardsList() {
       <List>
         {rewards
           ?.sort(compareChores)
-          .reverse()
+          .reverse() // sort descending
           .map((reward) => (
             <RewardCard
               key={reward.id}

--- a/client/src/parent/rewards/RewardsList.tsx
+++ b/client/src/parent/rewards/RewardsList.tsx
@@ -14,7 +14,7 @@ import { RewardCard } from "./RewardCard";
 import { useDashboardTitle } from "../../shell/hooks/DashboardTitleHook";
 import { useMyNotificationsByNamePrefixWithHandle } from "../../notifications/NotificationHooks";
 import { NotificationNames } from "../../notifications/NotificationNames";
-import { RewardWithGrants } from "../models/RewardWithGrants";
+import { compareChores, RewardWithGrants } from "../models/RewardWithGrants";
 import produce from "immer";
 import {
   mutateReward,
@@ -95,14 +95,17 @@ export function RewardsList() {
   return (
     <Box className={classes.container} component={Paper}>
       <List>
-        {rewards?.map((reward) => (
-          <RewardCard
-            key={reward.id}
-            reward={reward}
-            children={children ?? []}
-            onCopyReward={handleCopyReward}
-          />
-        ))}
+        {rewards
+          ?.sort(compareChores)
+          .reverse()
+          .map((reward) => (
+            <RewardCard
+              key={reward.id}
+              reward={reward}
+              children={children ?? []}
+              onCopyReward={handleCopyReward}
+            />
+          ))}
       </List>
       <Fab
         className={classes.fab}


### PR DESCRIPTION
Folgende Sortierung gilt jetzt für Ämtli und Belohnungen auf dem Parent Dashboard:
- Zuerst nach Anzahl offenen Aktionen (Bestätigungen).
- Dann nach Zeitpunkt der letzten Zustandsänderung.
- Zuletzt alphabetisch nach Name.

Durch den Sortieralgorithmus werden die Dashboards bei Änderungen jeweils umsortiert. Das kann möglicherweise beim Benutzer zu Verwirrung führen.
@TashunkoWitko , @StuderS41 , @marZeu8 : Schaut euch das Verhalten doch mal an. Was meint ihr dazu?